### PR TITLE
Replace `File::check()` with large match expression.

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -7,7 +7,6 @@ use std::path::PathBuf;
 #[derive(Parser, Debug)]
 #[command(version, about)]
 pub struct Args {
-
     #[arg(short, long)]
     pub verbose: bool,
 


### PR DESCRIPTION
I'm not sure how happy I really am with the block, mainly because while I like the surety of using large match blocks, I find they tend to get difficult to read when patterns span multiple lines. It makes the conditions look closer to the following case rather than their own case.

Unrelated changes are the result of running `cargo fmt`.