### PR TITLE
docs(readme): improve a bit

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,14 +59,14 @@ Note: any option set to `null` here is optional
 ```
 
 With the `sources` directory containing:
-```bash
+```console
 $ eza --long --no-user --no-time --no-filesize --tree -L 2 sources
 drwxr-xr-x sources
 .rw-r--r-- └── file
 ```
 
 And the `outputs` directory looking like this before hand:
-```bash
+```console
 $ eza --long --no-user --no-time --no-filesize --tree -L 2 outputs
 drwxr-xr-x outputs
 .rw-r--r-- ├── delete
@@ -74,7 +74,7 @@ drwxr-xr-x outputs
 ```
 
 This should output:
-```bash
+```console
 $ eza --long --no-user --no-time --no-filesize --tree -L 2 outputs
 drwxr-xr-x outputs
 drwxr-xr-x ├── directory


### PR DESCRIPTION
- JSON mistake was highlighted in the Github render
- `console` parser differentiates prompts (that start with `$` or `#`) from the "output" lines