### PR TITLE
Improve support for suid, sgid, and sticky bits

### DIFF
--- a/src/file_util.rs
+++ b/src/file_util.rs
@@ -248,7 +248,7 @@ impl FileWithMetadata {
                 permissions: Some(perms),
                 metadata: Some(ref metadata),
                 ..
-            } if perms != (metadata.mode() & 0o777) => Ok(false),
+            } if perms != (metadata.mode() & 0o7_777) => Ok(false),
             Self {
                 uid: Some(uid),
                 metadata: Some(ref metadata),
@@ -389,7 +389,7 @@ impl FileWithMetadata {
             if let Some(x) = self.permissions {
                 let new_perms = fs::Permissions::from_mode(x);
 
-                if metadata.mode() & 0o777 == new_perms.mode() {
+                if metadata.mode() & 0o7_777 == new_perms.mode() {
                     return Ok(());
                 }
                 info!(


### PR DESCRIPTION
SMFH would already accept permission settings above 0o777, but these would always be flagged as non-matching since the existing permissions would have the high bits masked off before checking. This patch preserves the high permission bits when performing said checks.