### PR TITLE
feat: clean subcommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -728,6 +728,7 @@ dependencies = [
  "clap",
  "color-eyre",
  "log",
+ "serde_json",
  "simplelog",
  "smfh-core",
 ]

--- a/crates/smfh-cli/Cargo.toml
+++ b/crates/smfh-cli/Cargo.toml
@@ -13,6 +13,7 @@ clap.workspace = true
 color-eyre.workspace = true
 log.workspace = true
 simplelog.workspace = true
+serde_json.workspace = true
 
 [lints]
 workspace = true

--- a/crates/smfh-cli/src/args.rs
+++ b/crates/smfh-cli/src/args.rs
@@ -55,4 +55,8 @@ pub enum Subcommands {
         #[arg()]
         manifest: PathBuf,
     },
+    Clean {
+        #[arg()]
+        manifest: PathBuf,
+    },
 }

--- a/crates/smfh-cli/src/main.rs
+++ b/crates/smfh-cli/src/main.rs
@@ -54,6 +54,17 @@ fn read_or_exit(path: &Path, impure: bool) -> Manifest {
         Err(e) => handle_read_error(e),
     }
 }
+fn verify(manifest: &Path, impure: bool) -> smfh_core::manifest::Manifest {
+    let m = read_or_exit(manifest, impure);
+    let errors = m.verify();
+    if !errors.is_empty() {
+        for e in &errors {
+            error!("{e}");
+        }
+        process::exit(3);
+    }
+    m
+}
 
 fn main() {
     color_eyre::install().expect("Failed to setup color_eyre");
@@ -109,15 +120,18 @@ fn main() {
             }
         }
         Subcommands::Verify { manifest } => {
-            let m = read_or_exit(&manifest, args.impure);
-            let errors = m.verify();
-            if !errors.is_empty() {
-                for e in &errors {
-                    error!("{e}");
-                }
-                process::exit(3);
-            }
+            _ = verify(&manifest, args.impure);
             info!("Manifest '{}' is valid", manifest.display());
+        }
+        Subcommands::Clean { manifest } => {
+            let m = verify(&manifest, args.impure);
+            match serde_json::to_string_pretty(&m) {
+                Ok(s) => println!("{s}"),
+                Err(e) => {
+                    error!("{e:?}");
+                    process::exit(1);
+                }
+            }
         }
     }
 }

--- a/crates/smfh-core/src/manifest.rs
+++ b/crates/smfh-core/src/manifest.rs
@@ -124,10 +124,20 @@ use std::{
     },
 };
 
+#[allow(clippy::ref_option, clippy::trivially_copy_pass_by_ref)]
+fn is_false(t: &Option<bool>) -> bool {
+    t.is_none_or(|x| !x)
+}
+#[allow(clippy::ref_option, clippy::trivially_copy_pass_by_ref)]
+fn is_true(t: &Option<bool>) -> bool {
+    t.is_none_or(|x| x)
+}
+
 /// Deserialized representation of a smfh manifest file.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Manifest {
     pub files: Vec<File>,
+    #[serde(skip_serializing_if = "is_false")]
     pub clobber_by_default: Option<bool>,
     pub version: u64,
     #[serde(skip)]
@@ -147,17 +157,28 @@ fn deserialize_octal<'de, D: Deserializer<'de>>(deserializer: D) -> Result<Optio
 /// A single file entry in a [`Manifest`].
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct File {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub source: Option<PathBuf>,
     pub target: PathBuf,
     #[serde(rename = "type")]
     pub kind: FileKind,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub clobber: Option<bool>,
-    #[serde(default, deserialize_with = "deserialize_octal")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_octal",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub permissions: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub uid: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub gid: Option<u32>,
+    #[serde(skip_serializing_if = "is_true")]
     pub deactivate: Option<bool>,
+    #[serde(skip_serializing_if = "is_true")]
     pub follow_symlinks: Option<bool>,
+    #[serde(skip_serializing_if = "is_false")]
     pub ignore_modification: Option<bool>,
 }
 


### PR DESCRIPTION
after: #40 
closes: #29

Adds a bunch of serde serialization skips so anything set to `None` or a default value isn't output, giving a minimal output