### PR TITLE
Surface per-file activation/deactivation failures

### DIFF
--- a/crates/smfh-cli/src/main.rs
+++ b/crates/smfh-cli/src/main.rs
@@ -89,10 +89,22 @@ fn main() {
 
     match args.sub_command {
         Subcommands::Deactivate { manifest } => {
-            read_or_exit(&manifest, args.impure).deactivate();
+            let failures = read_or_exit(&manifest, args.impure).deactivate();
+            if !failures.is_empty() {
+                for (path, err) in &failures {
+                    error!("Failed to deactivate {}: {err:?}", path.display());
+                }
+                process::exit(1);
+            }
         }
         Subcommands::Activate { manifest, prefix } => {
-            read_or_exit(&manifest, args.impure).activate(&prefix);
+            let failures = read_or_exit(&manifest, args.impure).activate(&prefix);
+            if !failures.is_empty() {
+                for (path, err) in &failures {
+                    error!("Failed to activate {}: {err:?}", path.display());
+                }
+                process::exit(1);
+            }
         }
         Subcommands::Diff {
             prefix,
@@ -112,6 +124,12 @@ fn main() {
                         process::exit(3);
                     }
                     DiffError::OldManifestRead(e) => handle_read_error(e),
+                    DiffError::ActivationFailed(failures) => {
+                        for (path, err) in &failures {
+                            error!("Failed to activate {}: {err}", path.display());
+                        }
+                        process::exit(1);
+                    }
                     DiffError::Other(e) => {
                         error!("{e:?}");
                         process::exit(1);

--- a/crates/smfh-core/src/file_util.rs
+++ b/crates/smfh-core/src/file_util.rs
@@ -197,26 +197,26 @@ impl FileWithMetadata {
                 }
 
                 let target = self.target.clone();
-                /*
-                 TODO: this doesn't work
-                 if target.metadata().unwrap().permissions().readonly() {
-                   return Err(eyre!("target file is unwriteable"));
-                 }
-                */
 
                 randomize_filename(self);
+                let temp_path = self.target.clone();
 
                 match self.kind {
                     FileKind::Symlink => self.symlink(),
                     FileKind::Copy => self.copy(),
                     _ => panic!("This should never happen"),
-                }?;
-                info!(
-                    "Renaming '{}' -> '{}'",
-                    &self.target.display(),
-                    target.display()
-                );
-                fs::rename(&self.target, target)?;
+                }
+                .and_then(|_| {
+                    info!(
+                        "Renaming '{}' -> '{}'",
+                        temp_path.display(),
+                        target.display()
+                    );
+                    fs::rename(&temp_path, &target).map_err(Into::into)
+                })
+                .inspect_err(|_| {
+                    let _ = fs::remove_file(&temp_path);
+                })?;
 
                 Ok(true)
             }

--- a/crates/smfh-core/src/manifest.rs
+++ b/crates/smfh-core/src/manifest.rs
@@ -48,6 +48,10 @@ impl std::error::Error for ReadError {}
 pub enum DiffError {
     OldManifestMissing,
     OldManifestRead(ReadError),
+    /// One or more files failed to activate or deactivate. Each entry is the
+    /// target path and the formatted error. Returned instead of `Ok(())` so
+    /// the manifest rename is skipped and the next run can retry.
+    ActivationFailed(Vec<(PathBuf, String)>),
     Other(color_eyre::Report),
 }
 
@@ -56,6 +60,17 @@ impl Display for DiffError {
         match self {
             Self::OldManifestMissing => write!(f, "old manifest does not exist"),
             Self::OldManifestRead(e) => write!(f, "{e}"),
+            Self::ActivationFailed(failures) => {
+                write!(
+                    f,
+                    "{} file(s) failed to activate/deactivate:",
+                    failures.len()
+                )?;
+                for (path, err) in failures {
+                    write!(f, "\n  {}: {err}", path.display())?;
+                }
+                Ok(())
+            }
             Self::Other(e) => write!(f, "{e}"),
         }
     }
@@ -364,35 +379,41 @@ impl Manifest {
     }
 
     /// Activates every file in the manifest, applying them to the filesystem in
-    /// dependency order.
-    pub fn activate(&mut self, prefix: &str) {
+    /// dependency order. Returns per-file failures; the caller decides whether
+    /// any failure is fatal.
+    pub fn activate(&mut self, prefix: &str) -> Vec<(PathBuf, color_eyre::Report)> {
         self.files.sort();
+        let mut failures = Vec::new();
         for mut file in self.files.iter().map(FileWithMetadata::from) {
-            _ = file
-                .activate(self.clobber_by_default, prefix)
-                .inspect_err(|err| {
-                    error!(
-                        "Failed to activate file: '{}'\n{:?}",
-                        file.target.display(),
-                        err
-                    );
-                });
+            if let Err(err) = file.activate(self.clobber_by_default, prefix) {
+                error!(
+                    "Failed to activate file: '{}'\n{:?}",
+                    file.target.display(),
+                    err
+                );
+                failures.push((file.target.clone(), err));
+            }
         }
+        failures
     }
 
     /// Removes every file in the manifest from the filesystem in reverse
-    /// dependency order.
-    pub fn deactivate(&mut self) {
+    /// dependency order. Returns per-file failures; the caller decides whether
+    /// any failure is fatal.
+    pub fn deactivate(&mut self) -> Vec<(PathBuf, color_eyre::Report)> {
         self.files.sort();
+        let mut failures = Vec::new();
         for mut file in self.files.iter().map(FileWithMetadata::from).rev() {
-            _ = file.deactivate().inspect_err(|err| {
+            if let Err(err) = file.deactivate() {
                 error!(
                     "Failed to deactivate file: '{}'\n{:?}",
                     file.target.display(),
                     err
                 );
-            });
+                failures.push((file.target.clone(), err));
+            }
         }
+        failures
     }
 
     /// Brings the filesystem from the state described by the manifest at
@@ -413,8 +434,17 @@ impl Manifest {
         let mut old_manifest = match old_path.try_exists() {
             Ok(true) => Self::read(old_path, self.impure).map_err(DiffError::OldManifestRead)?,
             Ok(false) if fallback => {
-                self.activate(prefix);
-                return Ok(());
+                let failures = self.activate(prefix);
+                return if failures.is_empty() {
+                    Ok(())
+                } else {
+                    Err(DiffError::ActivationFailed(
+                        failures
+                            .into_iter()
+                            .map(|(p, e)| (p, format!("{e:?}")))
+                            .collect(),
+                    ))
+                };
             }
             Ok(false) => return Err(DiffError::OldManifestMissing),
             Err(err) => return Err(DiffError::Other(color_eyre::Report::from(err))),
@@ -443,7 +473,11 @@ impl Manifest {
 
         // Remove files in old manifest
         // which aren't in new manifest
-        old_manifest.deactivate();
+        let mut failures: Vec<(PathBuf, String)> = old_manifest
+            .deactivate()
+            .into_iter()
+            .map(|(p, e)| (p, format!("{e:?}")))
+            .collect();
 
         for (old, new) in updated_files {
             if !old
@@ -523,8 +557,16 @@ impl Manifest {
         // Verified
         self.files.append(&mut same_files);
         // Activate new files
-        self.activate(prefix);
-        Ok(())
+        failures.extend(
+            self.activate(prefix)
+                .into_iter()
+                .map(|(p, e)| (p, format!("{e:?}"))),
+        );
+        if failures.is_empty() {
+            Ok(())
+        } else {
+            Err(DiffError::ActivationFailed(failures))
+        }
     }
 }
 


### PR DESCRIPTION
`Manifest::activate` and `Manifest::deactivate` returned `()` and swallowed all per-file errors and onlylogged them via `error!`. As a result, `Manifest::diff` returned `Ok(())` even when entries failed to land on disk. So if a file fails to activate, the manifest is still renamed into place. On the next invocation, the diff sees new-vs-new and finds nothing to do. The failed entry is silently
dropped until the next full generation change. See https://github.com/feel-co/nixos-core/pull/13#discussion_r3138631328 for the motivation.

**This is a breaking change**. For both the API and the CLI, there is a rather large change in behaviour so I'd like to publish 1.5 if you don't mind. For the API, the return types of `Manifest::activate` and `Manifest::deactivate` change from `()` to `Vec<(PathBuf, color_eyre::Report)>`. For the CLI, `smfh activate`, `smfh deactivate`, and `smfh diff` were changed to exit with 1 instead of the previous 0. Exit code 1 is alread the documented "generic failure" code, but it was just not being emitted in these cases before.

fixes #31 

Change-Id: I4104bc8a1b690c0fb7ef1df52e13f6626a6a6964