### PR TITLE
Feat: merge subcommand

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ pedantic = { level = "warn", priority = -1 }
 
 blanket_clippy_restriction_lints = "allow"
 # turn this on for more pain
-#restriction = { level = "warn", priority = -1 }
+restriction = { level = "warn", priority = -1 }
 
 allow_attributes_without_reason = "allow"
 question_mark_used = "allow"

--- a/README.md
+++ b/README.md
@@ -218,6 +218,11 @@ etc.). Exits with code 3 if errors are found.
 Reads the manifest, verifies it, and prints a normalized JSON representation.
 Useful for reformatting manifests or checking that they parse correctly.
 
+### `merge`
+
+Reads a list of manifests, folds the entries from right to left
+and prints the normalized JSON representation.
+
 ## Exit codes
 
 | Code | Meaning                                            |

--- a/crates/smfh-cli/src/args.rs
+++ b/crates/smfh-cli/src/args.rs
@@ -59,4 +59,8 @@ pub enum Subcommands {
         #[arg()]
         manifest: PathBuf,
     },
+    Merge {
+        #[arg(value_delimiter = ',')]
+        manifests: Vec<PathBuf>,
+    },
 }

--- a/crates/smfh-cli/src/main.rs
+++ b/crates/smfh-cli/src/main.rs
@@ -22,12 +22,28 @@ use smfh_core::{
         DiffError,
         Manifest,
         ReadError,
+        merge_files_from_manifests,
     },
 };
 use std::{
     path::Path,
-    process,
+    process::{
+        self,
+    },
 };
+
+fn print_manifest(manifest: &Manifest) {
+    let mut ordered = manifest.clone();
+    ordered.files.sort();
+    match serde_json::to_string_pretty(&ordered) {
+        #[expect(clippy::print_stdout)]
+        Ok(s) => println!("{s}"),
+        Err(e) => {
+            error!("{e:?}");
+            process::exit(1);
+        }
+    }
+}
 
 fn handle_read_error(err: ReadError) -> ! {
     match err {
@@ -152,13 +168,18 @@ fn main() {
             info!("Manifest '{}' is valid", manifest.display());
         }
         Subcommands::Clean { manifest } => {
-            let m = verify(&manifest, args.impure);
-            match serde_json::to_string_pretty(&m) {
-                #[expect(clippy::print_stdout)]
-                Ok(s) => println!("{s}"),
+            print_manifest(&verify(&manifest, args.impure));
+        }
+        Subcommands::Merge { manifests } => {
+            let deserialized_manifests = manifests
+                .iter()
+                .map(|m| read_or_exit(m, args.impure))
+                .collect();
+            match merge_files_from_manifests(deserialized_manifests) {
+                Ok(m) => print_manifest(&m),
                 Err(e) => {
-                    error!("{e:?}");
-                    process::exit(1);
+                    error!("{e}");
+                    process::exit(3);
                 }
             }
         }

--- a/crates/smfh-core/src/manifest.rs
+++ b/crates/smfh-core/src/manifest.rs
@@ -144,6 +144,7 @@ use serde::{
 use serde_json::Value;
 use shellexpand::path::full as shellexpand;
 use std::{
+    collections::HashMap,
     fs::{
         self,
     },
@@ -164,8 +165,55 @@ fn is_true(t: &Option<bool>) -> bool {
     t.is_none_or(|x| x)
 }
 
+trait Merge {
+    fn merge(&mut self, other: &Self);
+}
+
+impl<T: Clone> Merge for Option<T> {
+    fn merge(&mut self, other: &Self) {
+        if other.is_some() {
+            self.clone_from(other);
+        }
+    }
+}
+#[inline]
+/// Merges a list of [`manifest's`][Manifest] [`.file`][File] entries.
+/// Right hand side overrides left
+/// Not a deep merge only entire entries are overridden .
+///
+/// # Errors
+///
+///  Returns an error if:
+///
+///  - The Vec passed is empty
+pub fn merge_files_from_manifests(manifests: Vec<Manifest>) -> Result<Manifest> {
+    let right_most: &mut Manifest =
+        &mut manifests.last().ok_or_eyre("No manifests passed!")?.clone();
+    let mut map: HashMap<String, File> = HashMap::new();
+
+    for m in manifests {
+        for f in m.files {
+            let key = format!("{}-{}", f.kind, f.target.to_string_lossy());
+            map.entry(key)
+                .and_modify(|inner_file| {
+                    inner_file.source.merge(&f.source);
+                    inner_file.clobber.merge(&f.clobber);
+                    inner_file.permissions.merge(&f.permissions);
+                    inner_file.uid.merge(&f.uid);
+                    inner_file.gid.merge(&f.gid);
+                    inner_file.deactivate.merge(&f.deactivate);
+                    inner_file.follow_symlinks.merge(&f.follow_symlinks);
+                    inner_file.ignore_modification.merge(&f.ignore_modification);
+                })
+                .or_insert(f.clone());
+        }
+    }
+    right_most.files = map.into_values().collect();
+    Ok(right_most.to_owned())
+}
+
 /// Deserialized representation of a smfh manifest file.
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Manifest {
     pub files: Vec<File>,
     #[serde(skip_serializing_if = "is_false")]
@@ -573,11 +621,11 @@ impl Manifest {
                 );
             });
             if !res.unwrap_or(false) {
-                let mut new = new;
+                let mut mut_new = new;
                 if !clobber {
-                    new.clobber = Some(true);
+                    mut_new.clobber = Some(true);
                 }
-                self.files.push(new);
+                self.files.push(mut_new);
             }
         }
 


### PR DESCRIPTION
right hand side overrides left hand
manifests are updated, not completely overriden by more rightward manifests
arguments are passed like `smfh merge manifest1,manifest2,manifest3`
using hashmaps so we dont have to iterate over everything one million times

additional things:
Split `print_manifest` into it's own command in `crates/cli/main.rs` and sort file entries before printing
added `#[derive(Clone)]` to Manifest
renamed a shadowed variable in `smfh-core/src/manifest.rs`