### PR TITLE
fix: protected_files check for new files

### DIFF
--- a/crates/smfh-core/src/manifest.rs
+++ b/crates/smfh-core/src/manifest.rs
@@ -566,7 +566,9 @@ impl Manifest {
 
         let protected_targets: Vec<_> = updated_files
             .iter()
-            .filter_map(|(old, new)| {
+            .map(|(old, new)| (Some(old), new))
+            .chain(self.files.iter().map(|new| (None, new)))
+            .filter_map(|(old_opt, new)| {
                 let clobber = new
                     .clobber
                     .unwrap_or_else(|| self.clobber_by_default.unwrap_or(false));
@@ -585,7 +587,12 @@ impl Manifest {
                     return None;
                 }
 
-                (!old.check().unwrap_or(false)).then(|| new.target.clone())
+                // If file is not new, check that the old one was not modified
+                let conflict = match old_opt {
+                    Some(old) => !old.check().unwrap_or(false),
+                    None => true,
+                };
+                conflict.then(|| new.target.clone())
             })
             .collect();
         if !protected_targets.is_empty() {


### PR DESCRIPTION
This fix #60 

When a file is new (present in new manifest but not in the old one), there is no check to see if the file already exists and cannot be overwritten.

To fix this, I run the protected_targets check against the updated_files AND the self.files (new ones) to prevent this silent bug.

This change breaks some tests:
```
test manifest::tests::diff_repairs_dangling_symlink_when_clobber_false ... FAILED

failures:

---- manifest::tests::diff_repairs_dangling_symlink_when_source_changes stdout ----
[File { source: Some("/var/folders/_n/ngh69djj2klgv9kfy3bz3ygc0000gn/T/nix-shell.GwfrqJ/.tmpMVThtt/new-source"), target: "/var/folders/_n/ngh69djj2klgv9kfy3bz3ygc0000gn/T/nix-shell.GwfrqJ/.tmpMVThtt/target", kind: Symlink, clobber: Some(false), permissions: None, uid: None, gid: None, deactivate: None, follow_symlinks: None, ignore_modification: None }]

thread 'manifest::tests::diff_repairs_dangling_symlink_when_source_changes' (30248459) panicked at crates/smfh-core/src/manifest.rs:933:9:
assertion `left == right` failed
  left: "/private/var/folders/_n/ngh69djj2klgv9kfy3bz3ygc0000gn/T/nix-shell.GwfrqJ/.tmpMVThtt/new-source"
 right: "/var/folders/_n/ngh69djj2klgv9kfy3bz3ygc0000gn/T/nix-shell.GwfrqJ/.tmpMVThtt/new-source"

---- manifest::tests::diff_repairs_dangling_symlink_when_clobber_false stdout ----
[File { source: Some("/var/folders/_n/ngh69djj2klgv9kfy3bz3ygc0000gn/T/nix-shell.GwfrqJ/.tmpbwOTt1/source"), target: "/var/folders/_n/ngh69djj2klgv9kfy3bz3ygc0000gn/T/nix-shell.GwfrqJ/.tmpbwOTt1/target", kind: Symlink, clobber: Some(false), permissions: None, uid: None, gid: None, deactivate: None, follow_symlinks: None, ignore_modification: None }]

thread 'manifest::tests::diff_repairs_dangling_symlink_when_clobber_false' (30248458) panicked at crates/smfh-core/src/manifest.rs:900:9:
assertion `left == right` failed
  left: "/private/var/folders/_n/ngh69djj2klgv9kfy3bz3ygc0000gn/T/nix-shell.GwfrqJ/.tmpbwOTt1/source"
 right: "/var/folders/_n/ngh69djj2klgv9kfy3bz3ygc0000gn/T/nix-shell.GwfrqJ/.tmpbwOTt1/source"
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    manifest::tests::diff_repairs_dangling_symlink_when_clobber_false
    manifest::tests::diff_repairs_dangling_symlink_when_source_changes

test result: FAILED. 24 passed; 2 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s

error: test failed, to rerun pass `-p smfh-core --lib`
```

I don't have time to check this right now, so I will open this PR as draft for now.

I'm new to Rust and don't know all the best practices, feel free to change my work or fix this by an other manner !